### PR TITLE
Add response checking to `get_results()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,24 +33,24 @@ get_path_url <- function(path) {
   # auth
   if (auth$auth == "key") {
     query$hapikey <- auth$value
-    httr::GET(get_path_url(path),
+    res <- httr::GET(get_path_url(path),
       query = query,
       httr::user_agent("hubspot R package by Locke Data")
-    ) %>%
-      httr::content()
+    )
   } else {
     token <- readRDS(auth$value)
 
     token <- check_token(token, file = auth$value)
 
-    httr::GET(get_path_url(path),
+    res <- httr::GET(get_path_url(path),
       query = query,
       httr::config(httr::user_agent("hubspot R package by Locke Data"),
         token = token
       )
-    ) %>%
-      httr::content()
+    )
   }
+  httr::warn_for_status(res)
+  res %>% httr::content()
 }
 
 get_results <- ratelimitr::limit_rate(


### PR DESCRIPTION
From the [httr vignette](https://cran.r-project.org/web/packages/httr/vignettes/quickstart.html):

> ```
> warn_for_status(r)
> stop_for_status(r)
> ```
> I highly recommend using one of these functions whenever you’re using httr inside a function (i.e. not interactively) to make sure you find out about errors as soon as possible.